### PR TITLE
New export options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ extension. eg.
 .. code-block:: console
 
   somevar="test1"
+
   # This is a comment.
   anothervar="${somevar}"
   numbervar=123
@@ -109,6 +110,7 @@ output like so:
 .. code-block:: console
 
   somevar="test1"
+
   # This is a comment.
   anothervar="${somevar}"
   numbervar=123
@@ -126,7 +128,24 @@ installed or configured. eg.
 .. code-block:: console
 
   export somevar="test1"
+
   # This is a comment.
+  export anothervar="${somevar}"
+  export numbervar=123
+
+Note that if ``-e and -s`` are used together, `` export`` will be
+prefixed to each variable (note the leading space). This can be used
+in conjunction with setting `HISTCONTROL` to ``ignorespace`` or
+``ignoreboth`` to prevent variables from being saved to the shell
+history. See `info bash -n 'Bash Variables' HISTCONTROL` for details.
+
+It is also possible to "clean" the output of ``-s`` or ``-e`` of empty
+lines and comment lines by adding the ``-c`` flag. For example,
+instead of the above output, ``envswitch -ec`` might produce:
+
+.. code-block:: console
+
+  export somevar="test1"
   export anothervar="${somevar}"
   export numbervar=123
 

--- a/bin/envswitch
+++ b/bin/envswitch
@@ -24,15 +24,26 @@ shopt -s nullglob
 
 function export_environment()
 {
-	replacement_prefix='export '
-	if [ "${show_env}" -eq 1 ]
+	prefix=''
+	if [ "${show_env}" -eq 1 ] && [ "${export_opt}" -eq 1 ]
 	then
-		replacement_prefix=" ${replacement_prefix}"
+		prefix=" ${prefix}"
+	fi
+	if [ "${export_opt}" -eq 1 ]
+	then
+		prefix="${prefix}export "
 	fi
 	if [ -n "${ENVSWITCH_PROFILE}" ]
 	then
-		< "${config_dir}/${ENVSWITCH_PROFILE}.conf" \
-			sed -e 's/^\([^#]\+\)/'"${replacement_prefix}"'\1/g'
+		if [ "${comment_opt}" -eq 1 ]
+		then
+			< "${config_dir}/${ENVSWITCH_PROFILE}.conf" \
+				sed -e 's/^\([^#]\+\)/'"${prefix}"'\1/g' \
+					-e '/^\(#.*\)\?$/d'
+		else
+			< "${config_dir}/${ENVSWITCH_PROFILE}.conf" \
+				sed -e 's/^\([^#]\+\)/'"${prefix}"'\1/g'
+		fi
 	else
 		echo "No environment loaded."
 		exit 1
@@ -49,6 +60,7 @@ function print_help()
 	-l      list available environments
 	-s      show loaded environment variables
 	-e      show loaded environment variables (export mode)
+	-c      optional argument for -s or -e to strip comments and empty lines
 	-h      show this help message
 	
 	If both -e and -s are given, a single space is prefixed to export commands.
@@ -127,7 +139,13 @@ function show_environment()
 {
 	if [ -n "${ENVSWITCH_PROFILE}" ]
 	then
-		cat "${config_dir}/${ENVSWITCH_PROFILE}.conf"
+		if [ "${comment_opt}" -eq 1 ]
+		then
+			< "${config_dir}/${ENVSWITCH_PROFILE}.conf" \
+				sed -e '/^\(#.*\)\?$/d'
+		else
+			cat "${config_dir}/${ENVSWITCH_PROFILE}.conf"
+		fi
 	else
 		echo "No environment loaded."
 		exit 1
@@ -140,6 +158,7 @@ declare -i init_opt=0
 declare -i init_opt_nops1=0
 declare -i env_opt=0
 declare -i show_env=0
+declare -i comment_opt=0
 declare -i score=0
 
 if [ ! -d "${config_dir}" ]
@@ -148,9 +167,12 @@ then
 	mkdir -m 0700 "${config_dir}"
 fi
 
-while getopts "ehiIls" option
+while getopts "cehiIls" option
 do
 	case ${option} in
+		c )
+			comment_opt=1
+			;;
 		e )
 			export_opt=1
 			;;
@@ -193,6 +215,15 @@ elif [ ${score} -gt 1 ] &&
 	}
 then
 	echo "${0}: multiple options selected"
+	print_help
+	exit 1
+elif [ "${comment_opt}" -eq 1 ] &&
+	{
+		[ "${export_opt}" -ne 1 ] &&
+			[ "${show_env}" -ne 1 ]
+	}
+then
+	echo "${0}: -c is only valid with -e or -s"
 	print_help
 	exit 1
 else

--- a/bin/envswitch
+++ b/bin/envswitch
@@ -24,10 +24,15 @@ shopt -s nullglob
 
 function export_environment()
 {
+	replacement_prefix='export '
+	if [ "${show_env}" -eq 1 ]
+	then
+		replacement_prefix=" ${replacement_prefix}"
+	fi
 	if [ -n "${ENVSWITCH_PROFILE}" ]
 	then
-		sed -e 's/^\([^#]\+\)/export \1/g' \
-			"${config_dir}/${ENVSWITCH_PROFILE}.conf"
+		< "${config_dir}/${ENVSWITCH_PROFILE}.conf" \
+			sed -e 's/^\([^#]\+\)/'"${replacement_prefix}"'\1/g'
 	else
 		echo "No environment loaded."
 		exit 1
@@ -45,6 +50,8 @@ function print_help()
 	-s      show loaded environment variables
 	-e      show loaded environment variables (export mode)
 	-h      show this help message
+	
+	If both -e and -s are given, a single space is prefixed to export commands.
 	EOF
 }
 
@@ -169,7 +176,7 @@ do
 	esac
 done
 
-shift $(( OPTIND - 1))
+shift $(( OPTIND - 1 ))
 
 score=$(( export_opt + help_opt + init_opt + env_opt + \
 	show_env + init_opt_nops1 ))
@@ -178,7 +185,12 @@ then
 	echo "${0}: required option missing"
 	print_help
 	exit 1
-elif [ ${score} -gt 1 ]
+elif [ ${score} -gt 1 ] &&
+	{
+		[ "${score}" -ne 2 ] ||
+			[ "${export_opt}" -ne 1 ] ||
+			[ "${show_env}" -ne 1 ]
+	}
 then
 	echo "${0}: multiple options selected"
 	print_help

--- a/bin/envswitch
+++ b/bin/envswitch
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # -*- mode: sh; fill-column: 79; indent-tabs-mode: t; -*-
 #
-# Copyright 2015,2019 SitePoint Pty Ltd.
+# Copyright 2015,2019,2025 SitePoint Pty Ltd.
 # Author: Adam Bolte <adam.bolte@sitepoint.com>
 #
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Card
None (workflow enhancement)

## Description
Today I found myself deploying new ARM64 Docker containers for WordPress image processing. This involves me building the containers on a Raspberry Pi over SSH. In order to push the resulting containers to AWS, I have to copy across my secure environment variables.

I don't necessarily want my AWS credentials to just be sitting on the Raspberry Pi, so my workflow involves dumping the exports (using `-e`) and manually copying and pasting each entry line by line over my SSH connection. The reason for this is because I always add whitespace to ensure the Bash shell (with its default Debian configuration) will not store command history for these when entered.

This is obviously annoying and error prone, so now there is an easier, safer way. If `-s` is provided as a flag at the same time as `-e`, the exports will be preceded by a single space.

Additionally, a new `-c` flag has been added. This strips out the empty lines and comment lines. In some cases I had pages of output to copy and paste due to comments and formatting, and this has now been condensed to just a few lines.

## Demonstration
```
abolte@dragon:~$ ls -l .config/envswitch/pass-sitepoint.conf
-rw------- 1 abolte abolte 246 Jun  6  2023 .config/envswitch/pass-sitepoint.conf
abolte@dragon:~$ cat .config/envswitch/pass-sitepoint.conf
# http://git.zx2c4.com/password-store/about/
#
# Initialise with:
# pass init 0xF51B7834F92D586B 0x817EAD3F4E60B754...
#

PASSWORD_STORE_DIR="${HOME}/.password-store/sitepoint-shared"
PASSWORD_STORE_GIT="${HOME}/.password-store/sitepoint-shared"
abolte@dragon:~$ envswitch -s
No environment loaded.
abolte@dragon:~$ pass-sitepoint 
(pass-sitepoint) abolte@dragon:~$ envswitch -s
# http://git.zx2c4.com/password-store/about/
#
# Initialise with:
# pass init 0xF51B7834F92D586B 0x817EAD3F4E60B754...
#

PASSWORD_STORE_DIR="${HOME}/.password-store/sitepoint-shared"
PASSWORD_STORE_GIT="${HOME}/.password-store/sitepoint-shared"
(pass-sitepoint) abolte@dragon:~$ envswitch -e
# http://git.zx2c4.com/password-store/about/
#
# Initialise with:
# pass init 0xF51B7834F92D586B 0x817EAD3F4E60B754...
#

export PASSWORD_STORE_DIR="${HOME}/.password-store/sitepoint-shared"
export PASSWORD_STORE_GIT="${HOME}/.password-store/sitepoint-shared"
(pass-sitepoint) abolte@dragon:~$ envswitch -sc
PASSWORD_STORE_DIR="${HOME}/.password-store/sitepoint-shared"
PASSWORD_STORE_GIT="${HOME}/.password-store/sitepoint-shared"
(pass-sitepoint) abolte@dragon:~$ envswitch -ec
export PASSWORD_STORE_DIR="${HOME}/.password-store/sitepoint-shared"
export PASSWORD_STORE_GIT="${HOME}/.password-store/sitepoint-shared"
(pass-sitepoint) abolte@dragon:~$ envswitch -sec
 export PASSWORD_STORE_DIR="${HOME}/.password-store/sitepoint-shared"
 export PASSWORD_STORE_GIT="${HOME}/.password-store/sitepoint-shared"
(pass-sitepoint) abolte@dragon:~$ 
```